### PR TITLE
Update .gitignore for python repository caches

### DIFF
--- a/{{cookiecutter.app_name}}/.gitignore
+++ b/{{cookiecutter.app_name}}/.gitignore
@@ -1,5 +1,5 @@
 *.egg-info/
-*.py[cod]
+*.py[rcod]
 .cache/
 .eggs/
 .tox/


### PR DESCRIPTION
After running tox tests, python repository cache files are left in the project tree.  Git should ignore these .pyr files.